### PR TITLE
add handleScroll

### DIFF
--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -5,7 +5,12 @@ import { CustomButton } from ".";
 import Link from "next/link";
 
 export default function Hero() {
-  const handleScroll = () => {};
+  const handleScroll = () => {
+    // Get a reference to the fist element with the class name "searchbar"
+    const nextSection = document.querySelector(".searchbar");
+    // Scroll to the element with smooth behavior
+    nextSection?.scrollIntoView({ behavior: "smooth" });
+  };
   return (
     <div className="hero">
       <div className="flex-1 pt-36 padding-x">


### PR DESCRIPTION
The `handleScroll`function is designed to scroll the webpage to the element with the class "searchbar" in a smooth manner. 
- `document.querySelector` to obtain a reference to the HTML element with the class "searchbar". It looks for an element with the document's DOM that matches the specific CSS selector. 