### PR TITLE
add Scroll False

### DIFF
--- a/components/CustomFilter.tsx
+++ b/components/CustomFilter.tsx
@@ -12,8 +12,8 @@ export default function CustomFilter({ options, title }: CustomFilterProps) {
   const [selected, setSelected] = useState(options[0]);
 
   const handleUpdateParams = (e: { title: string; value: string }) => {
-    const newPathName = updateSearchParams(title, e.value.toLocaleLowerCase());
-    router.push(newPathName);
+    const newPathName = updateSearchParams(title, e.value.toLowerCase());
+    router.push(newPathName, { scroll: false });
   };
 
   return (

--- a/components/SearchBar.tsx
+++ b/components/SearchBar.tsx
@@ -49,7 +49,7 @@ export default function SearchBar() {
       window.location.pathname
     }?${searchParams.toString()}`;
 
-    router.push(newPathname);
+    router.push(newPathname, { scroll: false });
   };
 
   return (

--- a/components/ShowMore.tsx
+++ b/components/ShowMore.tsx
@@ -12,7 +12,7 @@ export default function ShowMore({ pageNumber, isNext }: ShowMoreProps) {
     const newLimit = (pageNumber + 1) * 10;
     const newPathName = updateSearchParams("limit", `${newLimit}`);
 
-    router.push(newPathName);
+    router.push(newPathName, { scroll: false });
   };
 
   return (

--- a/types/index.ts
+++ b/types/index.ts
@@ -48,6 +48,7 @@ export interface OptionProps {
 }
 
 export interface CustomFilterProps {
+  handleClick?: MouseEventHandler<HTMLButtonElement>;
   title: string;
   options: OptionProps[];
 }


### PR DESCRIPTION
add Scroll false in to router push `router.push(newPathName, { scroll: false })` to prevent the screen scroll up to the top of the website when the search button is clicked